### PR TITLE
Add tooltip for overflowing PR titles and move chips to next line

### DIFF
--- a/src/PullRequests/PullRequestTable.tsx
+++ b/src/PullRequests/PullRequestTable.tsx
@@ -6,11 +6,12 @@ import en from 'javascript-time-ago/locale/en'
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 import JiraLink from "./JiraLink";
 import { PullRequestFilter } from "./PullRequestFilter";
-import { getLabelStyle, GithubLabel } from "../GitHub/GithubLabel";
+import { GithubLabel } from "../GitHub/GithubLabel";
 import PullRequestChanges from "./PullRequestChanges";
 import ReviewStatus from "./ReviewStatus";
 import { fetchPullRequests } from './fetchPullRequests';
 import { GhProfile } from '../Profile/useGhProfile';
+import { PullRequestTitle } from './PullRequestTitle';
 
 TimeAgo.addDefaultLocale(en)
 let timeAgo = new TimeAgo();
@@ -26,20 +27,7 @@ const columns: GridColDef[] = [
     headerName: 'Title',
     flex: 3,
     renderCell: params => (
-      <div>
-        <Link href={params.getValue(params.id, 'link') as string}
-              target={'_blank'}
-              underline={'hover'}>
-          {params.value}
-        </Link>
-        <span>
-          {
-            (params.getValue(params.id, 'labels') as any).map((label: GithubLabel) => {
-              return (<Chip label={label.name} key={params.id} size="small" style={getLabelStyle(label)} sx={{height: 18}}/>)
-            })
-          }
-        </span>
-      </div>
+      <PullRequestTitle params={params} />
     )
   },
   {

--- a/src/PullRequests/PullRequestTitle.tsx
+++ b/src/PullRequests/PullRequestTitle.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react';
+import styled from '@emotion/styled';
+import { Chip, Link } from "@mui/material";
+import { GridRenderCellParams } from '@mui/x-data-grid';
+
+import { GithubLabel, getLabelStyle } from '../GitHub/GithubLabel';
+
+interface PullRequestTitleProps {
+  params: GridRenderCellParams
+}
+
+const StyledWrapper = styled.div({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const PullRequestTitle: FC<PullRequestTitleProps> = ({params}) => {
+  const title = params.value as string
+  const link = params.row.link as string
+  const labels = params.row.labels as GithubLabel[]
+
+  return (
+    <StyledWrapper>
+        <Link
+          href={link}
+          target={'_blank'}
+          underline={'hover'}
+          title={title}
+        >
+          {title}
+        </Link>
+        <div>
+          {labels.map((label) => {
+            return (
+              <Chip
+                title={label.name}
+                label={label.name}
+                key={label.name}
+                size="small"
+                style={getLabelStyle(label)}
+                sx={{height: 18}}
+              />
+            )
+          })}
+        </div>
+      </StyledWrapper>
+  )
+}


### PR DESCRIPTION
| before | after |
| ------- | ----- |
| <img width="397" alt="PR_before" src="https://github.com/dominikvoda/github-pr-dashboard/assets/89969651/c68db30e-02d3-4db5-b9b1-a2d8f52617ec"> | <img width="397" alt="image" src="https://github.com/dominikvoda/github-pr-dashboard/assets/89969651/fd047e10-cd40-4730-8017-a5ddedc4ff97"> |
