### PR TITLE
Add browser notifications for new PRs and auto-polling

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,8 @@
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+
+  const url = event.notification.data?.url
+  if (url) {
+    event.waitUntil(clients.openWindow(url))
+  }
+})

--- a/src/PullRequests/Dashboard.tsx
+++ b/src/PullRequests/Dashboard.tsx
@@ -2,12 +2,15 @@ import { Col, Container, Navbar, Row } from "react-bootstrap";
 import RepositoryFilter from "./RepositoryFilter";
 import Profile from "../Profile/Profile";
 import PullRequestTable from "./PullRequestTable";
-import React from "react";
+import React, { useMemo } from "react";
 import LabelFilter from "./LabelFilter";
 import { createEmptyFilter, PullRequestFilter } from "./PullRequestFilter";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
 import { useGhProfile } from "../Profile/useGhProfile";
+import { usePolling } from "../hooks/usePolling";
+import { buildFilterString } from "./buildFilterString";
+import NotificationToggle from "../notifications/NotificationToggle";
 
 export default function Dashboard() {
   const ghProfile = useGhProfile()
@@ -20,6 +23,9 @@ export default function Dashboard() {
 
     return JSON.parse(stored);
   });
+
+  const filters = useMemo(() => buildFilterString(pullRequestFilter), [pullRequestFilter.repositories, pullRequestFilter.labels])
+  const { rows, isLoading, lastPollTime } = usePolling(filters)
 
   const handleChangeRepositories = (selectedRepositories: any) => {
     const newPullRequestFilter: PullRequestFilter = {
@@ -66,6 +72,7 @@ export default function Dashboard() {
             Pull Requests
           </Navbar.Brand>
           <Navbar.Collapse className="justify-content-end">
+            <NotificationToggle />
             <Profile ghProfile={ghProfile}/>
           </Navbar.Collapse>
         </Container>
@@ -78,13 +85,21 @@ export default function Dashboard() {
           <Col md={3}>
             <LabelFilter pullRequestFilter={pullRequestFilter} onSelectedLabelsChange={handleChangeLabels}/>
           </Col>
-          <Col md={3}>
+          <Col md={2}>
             <FormControlLabel control={<Checkbox onChange={handleFilterApprovedChange} checked={pullRequestFilter.filterApproved} />} label="Filter out approved PRs" />
+          </Col>
+          <Col md={2} className="d-flex align-items-center justify-content-end">
+            {isLoading && <span style={{color: '#666', fontSize: '0.85rem'}}>Refreshing…</span>}
+            {!isLoading && lastPollTime && (
+              <span style={{color: '#999', fontSize: '0.85rem'}}>
+                Updated {lastPollTime.toLocaleTimeString()}
+              </span>
+            )}
           </Col>
         </Row>
         <Row style={{marginTop: '20px'}}>
           <Col>
-            <PullRequestTable ghProfile={ghProfile} pullRequestFilter={pullRequestFilter}/>
+            <PullRequestTable rows={rows} ghProfile={ghProfile} pullRequestFilter={pullRequestFilter}/>
           </Col>
         </Row>
       </Container>

--- a/src/PullRequests/PullRequestTable.tsx
+++ b/src/PullRequests/PullRequestTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { DataGrid, GridColDef, GridRenderCellParams, } from '@mui/x-data-grid';
 import { Avatar, AvatarGroup, Badge, Chip, Link } from "@mui/material";
 import TimeAgo from 'javascript-time-ago'
@@ -6,10 +6,8 @@ import en from 'javascript-time-ago/locale/en'
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 import JiraLink from "./JiraLink";
 import { PullRequestFilter } from "./PullRequestFilter";
-import { GithubLabel } from "../GitHub/GithubLabel";
 import PullRequestChanges from "./PullRequestChanges";
 import ReviewStatus from "./ReviewStatus";
-import { fetchPullRequests } from './fetchPullRequests';
 import { GhProfile } from '../Profile/useGhProfile';
 import { PullRequestTitle } from './PullRequestTitle';
 
@@ -17,6 +15,7 @@ TimeAgo.addDefaultLocale(en)
 let timeAgo = new TimeAgo();
 
 export interface PullRequestTableProps {
+  rows: any[],
   pullRequestFilter: PullRequestFilter,
   ghProfile: GhProfile,
 }
@@ -132,50 +131,22 @@ const columns: GridColDef[] = [
 ];
 
 export default function PullRequestTable(props: PullRequestTableProps) {
-  const [rows, setRows] = React.useState<any[]>([])
-
-  const loadPullRequests = useCallback(async (): Promise<void> => {
-    setRows([])
-    let filters = ''
-
-    props.pullRequestFilter.repositories.forEach((repository: any) => (
-      filters += ' repo:BrandEmbassy/' + repository
-    ))
-
-    props.pullRequestFilter.labels.forEach((label: GithubLabel) => (
-      filters += ' label:"' + label.name + '"'
-    ))
-
-    if (filters === '') {
-      filters = ' org:BrandEmbassy'
-    }
-
-    let rows = await fetchPullRequests(filters)
-    setRows(rows)
-  }, [props.pullRequestFilter.labels, props.pullRequestFilter.repositories])
-
-
   const filteredRows = useMemo(() => {
     if (!props.pullRequestFilter.filterApproved) {
-      return rows
+      return props.rows
     }
 
-    return rows.filter((pr) => {
+    return props.rows.filter((pr) => {
       const myReview = (pr.reviews as Array<any>).find((review) => review.user.id === props.ghProfile.id)
 
       if (!myReview) {
         return true
       }
-      console.log(myReview);
 
       return myReview.state !== "APPROVED"
     })
 
-  }, [props.ghProfile.id, props.pullRequestFilter.filterApproved, rows])
-
-  React.useEffect(() => {
-    loadPullRequests()
-  }, [loadPullRequests, props.pullRequestFilter]);
+  }, [props.ghProfile.id, props.pullRequestFilter.filterApproved, props.rows])
 
   return (
     <div style={{display: 'flex', marginBottom: '20px'}}>

--- a/src/PullRequests/buildFilterString.ts
+++ b/src/PullRequests/buildFilterString.ts
@@ -1,0 +1,19 @@
+import { PullRequestFilter } from "./PullRequestFilter"
+
+export function buildFilterString(filter: PullRequestFilter): string {
+  let filters = ''
+
+  filter.repositories.forEach((repository: any) => (
+    filters += ' repo:BrandEmbassy/' + repository
+  ))
+
+  filter.labels.forEach((label) => (
+    filters += ' label:"' + label.name + '"'
+  ))
+
+  if (filters === '') {
+    filters = ' org:BrandEmbassy'
+  }
+
+  return filters
+}

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { fetchPullRequests } from '../PullRequests/fetchPullRequests'
+import { loadSeenPrKeys, saveSeenPrKeys, makePrKey } from '../notifications/seenPrStore'
+import { showPrNotification } from '../notifications/notificationService'
+
+const POLL_INTERVAL_MS = 60_000
+
+interface UsePollingResult {
+  rows: any[]
+  isLoading: boolean
+  lastPollTime: Date | null
+}
+
+export function usePolling(filters: string): UsePollingResult {
+  const [rows, setRows] = useState<any[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastPollTime, setLastPollTime] = useState<Date | null>(null)
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const seenKeysRef = useRef<Set<string> | null>(null)
+  const isFirstFetchRef = useRef(true)
+  const filtersRef = useRef(filters)
+  const isFetchingRef = useRef(false)
+
+  // Keep filtersRef in sync
+  filtersRef.current = filters
+
+  const poll = useCallback(async (isFilterChange: boolean) => {
+    if (isFetchingRef.current) return
+    isFetchingRef.current = true
+    setIsLoading(true)
+
+    try {
+      const fetchedRows = await fetchPullRequests(filtersRef.current)
+      setRows(fetchedRows)
+      setLastPollTime(new Date())
+
+      // Build set of fetched PR keys
+      const fetchedKeys = new Set(
+        fetchedRows.map((row: any) => makePrKey(row.repository, row.number))
+      )
+
+      // Load seen keys on first call
+      if (seenKeysRef.current === null) {
+        const stored = loadSeenPrKeys()
+        seenKeysRef.current = stored ?? new Set()
+      }
+
+      const isFirstEver = isFirstFetchRef.current && seenKeysRef.current.size === 0
+      isFirstFetchRef.current = false
+
+      if (isFirstEver || isFilterChange) {
+        // Seed/merge: don't notify
+        console.log('[Polling] Seeding', fetchedKeys.size, 'PRs as seen (firstEver:', isFirstEver, 'filterChange:', isFilterChange, ')')
+        fetchedKeys.forEach(key => seenKeysRef.current!.add(key))
+      } else {
+        // Notify for genuinely new PRs
+        const newPrs: string[] = []
+        for (const row of fetchedRows) {
+          const key = makePrKey(row.repository, row.number)
+          if (!seenKeysRef.current.has(key)) {
+            seenKeysRef.current.add(key)
+            newPrs.push(key)
+            showPrNotification(row).catch(e => console.error('[Notifications] Error:', e))
+          }
+        }
+        if (newPrs.length > 0) {
+          console.log('[Polling] New PRs detected:', newPrs)
+        } else {
+          console.log('[Polling] No new PRs (', fetchedKeys.size, 'fetched,', seenKeysRef.current.size, 'seen)')
+        }
+      }
+
+      saveSeenPrKeys(seenKeysRef.current)
+    } finally {
+      setIsLoading(false)
+      isFetchingRef.current = false
+    }
+  }, [])
+
+  // Start/restart polling when filters change
+  useEffect(() => {
+    // Clear existing interval
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current)
+    }
+
+    // Fetch immediately (filter change = merge into seen, no notifications)
+    const isFilterChange = !isFirstFetchRef.current
+    poll(isFilterChange)
+
+    // Set up recurring poll
+    intervalRef.current = setInterval(() => poll(false), POLL_INTERVAL_MS)
+
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current)
+      }
+    }
+  }, [filters, poll])
+
+  // Poll immediately when tab becomes visible again
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        poll(false)
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [poll])
+
+  return { rows, isLoading, lastPollTime }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,3 +17,8 @@ ReactDOM.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();
+
+// Register service worker for notification click handling
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js')
+}

--- a/src/notifications/NotificationToggle.tsx
+++ b/src/notifications/NotificationToggle.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import { IconButton, Tooltip } from '@mui/material'
+import NotificationsIcon from '@mui/icons-material/Notifications'
+import NotificationsOffIcon from '@mui/icons-material/NotificationsOff'
+import {
+  isNotificationSupported,
+  getNotificationPermission,
+  requestNotificationPermission,
+  isNotificationsEnabled,
+  setNotificationsEnabled,
+} from './notificationService'
+
+export default function NotificationToggle() {
+  const [permission, setPermission] = useState(getNotificationPermission())
+  const [enabled, setEnabled] = useState(isNotificationsEnabled())
+
+  if (!isNotificationSupported()) {
+    return null
+  }
+
+  const handleClick = async () => {
+    if (permission === 'default') {
+      const result = await requestNotificationPermission()
+      setPermission(result)
+      if (result === 'granted') {
+        setEnabled(true)
+        setNotificationsEnabled(true)
+      }
+      return
+    }
+
+    if (permission === 'granted') {
+      const next = !enabled
+      setEnabled(next)
+      setNotificationsEnabled(next)
+      return
+    }
+  }
+
+  const isActive = permission === 'granted' && enabled
+
+  const tooltip =
+    permission === 'denied'
+      ? 'Notifications blocked — enable in browser settings'
+      : permission === 'default'
+        ? 'Enable notifications for new PRs'
+        : enabled
+          ? 'Notifications on (click to disable)'
+          : 'Notifications off (click to enable)'
+
+  return (
+    <Tooltip title={tooltip}>
+      <span>
+        <IconButton
+          onClick={handleClick}
+          disabled={permission === 'denied'}
+          sx={{ color: isActive ? '#4caf50' : '#999', mr: 1 }}
+          size="small"
+        >
+          {isActive ? <NotificationsIcon /> : <NotificationsOffIcon />}
+        </IconButton>
+      </span>
+    </Tooltip>
+  )
+}

--- a/src/notifications/notificationService.ts
+++ b/src/notifications/notificationService.ts
@@ -1,0 +1,64 @@
+export function isNotificationSupported(): boolean {
+  return 'Notification' in window
+}
+
+export function getNotificationPermission(): NotificationPermission {
+  if (!isNotificationSupported()) {
+    return 'denied'
+  }
+  return Notification.permission
+}
+
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!isNotificationSupported()) {
+    return 'denied'
+  }
+  return Notification.requestPermission()
+}
+
+export function isNotificationsEnabled(): boolean {
+  return localStorage.getItem('notificationsEnabled') !== 'false'
+}
+
+export function setNotificationsEnabled(enabled: boolean): void {
+  localStorage.setItem('notificationsEnabled', String(enabled))
+}
+
+export async function showPrNotification(row: { title: string; author: string; repository: string; link: string; number: number }): Promise<void> {
+  const permission = getNotificationPermission()
+  const enabled = isNotificationsEnabled()
+
+  if (permission !== 'granted' || !enabled) {
+    console.log('[Notifications] Skipped — permission:', permission, 'enabled:', enabled)
+    return
+  }
+
+  const tag = `${row.repository}/${row.number}`
+  const options: NotificationOptions = {
+    body: `${row.author} — ${row.repository}`,
+    tag,
+    icon: '/favicon.ico',
+    data: { url: row.link },
+  }
+
+  console.log('[Notifications] Showing notification for:', tag, row.title)
+
+  // Prefer service worker notifications (work reliably in background tabs)
+  if ('serviceWorker' in navigator) {
+    try {
+      const reg = await navigator.serviceWorker.ready
+      await reg.showNotification(row.title, options)
+      console.log('[Notifications] Shown via service worker')
+      return
+    } catch (e) {
+      console.warn('[Notifications] SW notification failed, falling back:', e)
+    }
+  }
+
+  const notification = new Notification(row.title, options)
+  notification.onclick = () => {
+    window.open(row.link)
+    notification.close()
+  }
+  console.log('[Notifications] Shown via Notification API')
+}

--- a/src/notifications/seenPrStore.ts
+++ b/src/notifications/seenPrStore.ts
@@ -1,0 +1,17 @@
+const STORAGE_KEY = 'seenPrKeys'
+
+export function loadSeenPrKeys(): Set<string> | null {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === null) {
+    return null // Never initialized — caller should seed
+  }
+  return new Set(JSON.parse(stored))
+}
+
+export function saveSeenPrKeys(keys: Set<string>): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...keys]))
+}
+
+export function makePrKey(repository: string, number: number): string {
+  return `${repository}/${number}`
+}


### PR DESCRIPTION
## Summary
- Auto-poll GitHub API every 60s for new PRs, with immediate refresh on tab focus via `visibilitychange`
- Track seen PRs in localStorage and show browser notifications when new ones appear
- Minimal service worker for reliable background-tab notifications and click handling
- Notification toggle (bell icon) in navbar with permission management
- Lift data fetching from `PullRequestTable` into a `usePolling` hook at the `Dashboard` level — table is now a pure display component
- "Updated HH:MM:SS" / "Refreshing…" status indicator in the filter row

## Test plan
- [x] Verify PR table loads and auto-refreshes every 60s
- [x] Grant notification permission via the bell icon in navbar
- [x] Confirm no notification spam on first load (existing PRs seeded as "seen")
- [x] Wait for a new PR to appear (or remove an entry from `seenPrKeys` in localStorage + reload) and verify browser notification fires
- [x] Click a notification and verify it opens the PR on GitHub
- [x] Switch to another tab, wait 60s+, confirm notification still appears
- [x] Return to tab and confirm data refreshes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)